### PR TITLE
Add .packages file to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 pubspec.lock
 packages/
+.packages
 test/packages
 build
 web/packages


### PR DESCRIPTION
As of 1.12, the .packages file exists after running pub get. Don’t check it
into source control.
